### PR TITLE
Domain-Fix bei E-Mail-Links und zusätzliche Environment-Variablen

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ Die Konfiguration lässt sich in der `config.env` und in der `docker-compose.yml
 
 ## Libertas mitentwickeln
 
-Libertas ist bewusst open source und kann von jedem mitentwickelt werden! Du findest alle Informationen dazu unter [CONTRIBUTING](https://github.com/the-haps/libertas/blob/development/CONTRIBUTING).
+Libertas ist bewusst open source und kann von jedem mitentwickelt werden! Du findest alle Informationen dazu unter [CONTRIBUTING](https://github.com/the-haps/libertas/blob/development/CONTRIBUTING.md).

--- a/config.env
+++ b/config.env
@@ -23,3 +23,8 @@ DJANGO_SMTP_USE_TLS=0
 
 # Python
 PYTHONUNBUFFERED=1
+
+# Libertas
+LIBERTAS_EMAIL_FROM=Libertas <noreply@localhost>
+LIBERTAS_DOMAIN=http://localhost:8000
+LIBERTAS_BETA=0

--- a/core/settings.py
+++ b/core/settings.py
@@ -27,7 +27,7 @@ DEBUG = bool(int(os.environ['DJANGO_DEBUG']))
 
 ALLOWED_HOSTS = os.environ['DJANGO_ALLOWED_HOSTS']
 
-DEFAULT_FROM_EMAIL = 'Libertas <noreply@libertas.de>'
+DEFAULT_FROM_EMAIL = os.environ['LIBERTAS_EMAIL_FROM']
 
 # Application definition
 

--- a/libertas/templates/libertas/auth/reset_email.html
+++ b/libertas/templates/libertas/auth/reset_email.html
@@ -3,7 +3,7 @@ Hallo!
 
 Bitte klicke auf folgenden Link, um dein Passwort zurückzusetzen:
 
-http://{{ domain }}{% url 'reset_confirm' uidb64=uid token=token %}
+{{ domain }}{% url 'reset_confirm' uidb64=uid token=token %}
 
 
 Solltest du das Zurücksetzen deines Passworts nicht veranlasst

--- a/libertas/templates/libertas/auth/signup_email.html
+++ b/libertas/templates/libertas/auth/signup_email.html
@@ -3,7 +3,7 @@ Hallo!
 
 Bitte klicke auf folgenden Link, um deinen Libertas-Account zu aktivieren:
 
-http://{{ domain }}{% url 'signup_activate' uidb64=uid token=token %}
+{{ domain }}{% url 'signup_activate' uidb64=uid token=token %}
 
 
 Solltest du dich nicht für ein Libertas-Account registriert

--- a/libertas/views.py
+++ b/libertas/views.py
@@ -10,6 +10,7 @@ from .tokens import signup_token, reset_token
 from django.contrib.admin.models import LogEntry, CHANGE, ADDITION
 from django.contrib.contenttypes.models import ContentType
 from django.contrib import messages
+import os
 
 # Create your views here.
 
@@ -98,7 +99,8 @@ def signup(request):
             subject = 'Aktiviere deinen Libertas-Account'
             message = render_to_string('libertas/auth/signup_email.html', {
                 'user': user,
-                'domain': current_site.domain,
+                'domain': os.environ['LIBERTAS_DOMAIN'],
+                'beta': bool(int(os.environ['LIBERTAS_BETA'])),
                 'uid': urlsafe_base64_encode(force_bytes(user.pk)),
                 'token': signup_token.make_token(user),
             })
@@ -146,7 +148,8 @@ def reset(request):
                 subject = 'Setzte das Passwort von deinem Libertas-Account zurück'
                 message = render_to_string('libertas/auth/reset_email.html', {
                     'user': user,
-                    'domain': current_site.domain,
+                    'domain': os.environ['LIBERTAS_DOMAIN'],
+                    'beta': bool(int(os.environ['LIBERTAS_BETA'])),
                     'uid': urlsafe_base64_encode(force_bytes(user.pk)),
                     'token': reset_token.make_token(user),
                 })


### PR DESCRIPTION
Über Environment-Variablen lassen sich nun E-Mail-Absenderadresse, Domain und Beta-Status konfigurieren. Die Domain wird für die Verifizierungslinks verwendet, sodass nun endlich die richtigen Links generiert werden, u.a um die E-Mail zu bestätigen.